### PR TITLE
自分以外のメニューを献立として登録できてしまう（認可漏れ） #3

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 
 class MealRecordController extends Controller
 {
@@ -43,12 +44,33 @@ class MealRecordController extends Controller
         }
 
         // 2. バリデーション
+        $userId = Auth::id();    //今ログインしている人のIDを取得
+
         $validated = $request->validate([
-        // exists:テーブル名,カラム名 という書き方にします
-            'main_dish_id'  => 'required|exists:menus,id',
-            'sub_dish_a_id' => 'required|exists:menus,id',
-            'sub_dish_b_id' => 'required|exists:menus,id',
+            'main_dish_id' => [
+                'required', Rule::exists('menus', 'id')
+                ->where('user_id', $userId)->where('type_id', 1)
+            ],
+            'sub_dish_a_id' => [
+                'required', Rule::exists('menus', 'id')
+                ->where('user_id', $userId)->where('type_id', 2)
+            ],
+            'sub_dish_b_id' => [
+                'required', Rule::exists('menus', 'id')
+                ->where('user_id', $userId)->where('type_id', 3)
+            ], [
+                'main_dish_id.exists' => '選択された主菜は無効です。',
+                'main_dish_a_id.exists' => '選択された副菜Aは無効です。',
+                'main_dish_b_id.exists' => '選択された副菜Bは無効です。',
+            ]
         ]);
+
+        // $validated = $request->validate([
+        // // exists:テーブル名,カラム名 という書き方にします
+        //     'main_dish_id'  => 'required|exists:menus,id',
+        //     'sub_dish_a_id' => 'required|exists:menus,id',
+        //     'sub_dish_b_id' => 'required|exists:menus,id',
+        // ]);
 
         try {
             // 3. トランザクション（親子の保存をセットで行う）


### PR DESCRIPTION
MealRecordControll.phpを修正

①認可漏れ（誰の持ち物か）
---
問題：もしID:500のメニューIDが「Aさんの非公開メニュー」だった場合、現状のバリデーションだとパスしてしまう。
　　　なぜならそのIDが存在しているかexists()しか確認していないから。
　　　そうなると、別の人の献立履歴に「Aさんの非公開メニュー」が保存されてしまう。

②整合性の欠如（役割のチェック）
---
問題：main_dish_idに「冷奴」（副菜B）のIDを入れて送ってもmenusテーブルに存在するIDなので
　　　meal_record_itemsテーブルには「主菜」として登録されているのに中身は「冷奴」（副菜B）という
　　　不整合が起きる
　　　後に「主菜の統計」などを取った時にデータがめちゃくちゃになってしまう

③DevToolsで攻撃される可能性
---
現実：悪意あるユーザーや知識のあるユーザーは画面を通さずに直接サーバーに「ID：99999を登録して」などの
　　　命令を送ることがでる。
　　　「画面上で選べないようにする」だけでは不十分なため「サーバーにデータが届いた瞬間に再度チェックをする」ことで
　　　悪意のある攻撃を防ぐ

**修正**
```
$userId = Auth::id();    //今ログインしている人のIDを取得

        $validated = $request->validate([
            'main_dish_id' => [
                'required', Rule::exists('menus', 'id')
                ->where('user_id', $userId)->where('type_id', 1)
            ],
            'sub_dish_a_id' => [
                'required', Rule::exists('menus', 'id')
                ->where('user_id', $userId)->where('type_id', 2)
            ],
            'sub_dish_b_id' => [
                'required', Rule::exists('menus', 'id')
                ->where('user_id', $userId)->where('type_id', 3)
            ], [
                'main_dish_id.exists' => '選択された主菜は無効です。',
                'main_dish_a_id.exists' => '選択された副菜Aは無効です。',
                'main_dish_b_id.exists' => '選択された副菜Bは無効です。',
            ]
        ]);
```

**確認方法**
console画面で次のコードを実行して確認
```
// 1. Laravelのセキュリティ（CSRF）トークンを取得
const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');

// 2. 不正なデータを送信する（IDの部分を、DBにある「他人のID」などに書き換える）
fetch('/meal-records', {
    method: 'POST',
    headers: {
        'Content-Type': 'application/json',
        'X-CSRF-TOKEN': token,
        'Accept': 'application/json' // これにより、エラー時にJSONで返ってくる
    },
    body: JSON.stringify({
        main_dish_id: 1,  // ここを「他人のメニューID」に書き換え
        sub_dish_a_id: 2, // ここを「本来は主菜のメニューID」などに書き換え
        sub_dish_b_id: 3
    })
})
.then(response => {
    console.log('ステータスコード:', response.status);
    return response.json();
})
.then(data => {
    console.log('サーバーからのレスポンス:', data);
    if (response.status === 200 || response.status === 201) {
        console.warn('⚠️ 警告: 他人のデータなのに登録に成功してしまいました（認可漏れの状態）');
    } else if (response.status === 422) {
        console.log('✅ 成功: バリデーションでブロックされました');
    }
})
.catch(error => console.error('エラーが発生しました:', error));
```