### PR TITLE
MenuController::destroy() の認可設計が矛盾しています #5

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -55,10 +55,27 @@ class MenuController extends Controller
     }
 
     public function index() {
-        // 1. ログインユーザーのメニューのみを取得
-        $menus = Menu::where('user_id', auth()->id())
-                    ->orderBy('created_at', 'desc')
-                    ->get();
+        // 現在ログインしているユーザー情報を取得
+        $user = Auth::user();
+
+        // 権限に応じて取得するメニューを分岐
+        if($user->role === 'admin') {
+            // 管理者の場合：すべてのユーザーのメニューを取得
+            $menus = Menu::with(['user', 'type'])
+                        ->orderBy('created_at', 'desc')
+                        ->get();
+        } else {
+            // 一般ユーザーの場合：自分のメニューのみ取得
+            $menus = Menu::where('user_id', $user->id)
+                        ->with('type')
+                        ->orderBy('created_at', 'desc')
+                        ->get();
+        }
+
+        // // 1. ログインユーザーのメニューのみを取得
+        // $menus = Menu::where('user_id', auth()->id())
+        //             ->orderBy('created_at', 'desc')
+        //             ->get();
 
         // 2. 登録フォーム用セレクトボックス用データ
         $types = Type::all();
@@ -67,13 +84,24 @@ class MenuController extends Controller
     }
 
     public function destroy(Menu $menu) {
-        // 1. ログインユーザーとメニューの所有者が一致しているかをチェック
-        if($menu->user_id !== auth()->id()) {
+        // 現在ログインしているユーザー
+        $user = Auth::user();
+
+        // 認可チェック：「メニューの所有者ではない」かつ「管理者でもない」場合
+        if($menu->user_id !== $user->id && $user->role !== 'admin') {
             return redirect()->route('menus.index')->with([
                 'message' => '削除する権限がありません',
                 'type' => 'danger',
             ]);
         }
+
+        // // 1. ログインユーザーとメニューの所有者が一致しているかをチェック
+        // if($menu->user_id !== auth()->id()) {
+        //     return redirect()->route('menus.index')->with([
+        //         'message' => '削除する権限がありません',
+        //         'type' => 'danger',
+        //     ]);
+        // }
 
         // 2. サーバー上の画像を削除
         if($menu->image_path) {

--- a/resources/views/menus/partials/list-items.blade.php
+++ b/resources/views/menus/partials/list-items.blade.php
@@ -14,6 +14,11 @@
             <div class="flex-grow text-left">
                 <h3 class="text-orange-800 font-bold text-[18px] leading-[1.7]">{{ $menu->name }}</h3>
                 <p class="text-orange-600 text-sm">{{ $menu->type->name ?? '未分類' }}</p>
+                                            {{-- 管理者の場合のみ投稿者名を表示 --}}
+                @if (auth()->user()->role === 'admin')
+                    <p class="mt-1 text-gray-500 text-xs">投稿者： {{ $menu->user->name }}</p>
+                @endif
+
             </div>
 
             {{-- 右：削除ボタン --}}
@@ -35,7 +40,8 @@
                         <button disabled class="flex items-center opacity-30 cursor-not-allowed" title="管理者権限が必要です"><span class="mr-1">⬆️</span>メニュー管理（制限中）</a>
                     @endcan --}}
 
-                @can('admin')
+                @if ($menu->user_id === auth()->id() || auth()->user()->role === 'admin')
+                    {{-- 削除可能な場合の表示（ゴミ箱アイコン） --}}
                     <button type="button" class="p-2 text-gray-800 hover:text-red-500 transition delete-individual-btn" data-name="{{ $menu->name }}">
                         {{-- ゴミ箱アイコン（SVG） --}}
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -43,13 +49,14 @@
                         </svg>
                     </button>
                 @else
-                    <button disabled class="p-2 text-gray-800 hover:text-red-500 transition delete-individual-btn cursor-not-allowed" title="管理者権限が必要です">
+                    {{-- 削除できない場合（非活性なボタンや何も表示しない） --}}
+                    <button disabled class="p-2 text-gray-800 hover:text-red-500 transition delete-individual-btn cursor-not-allowed" title="登録者本人か管理者権限が必要です">
                         {{-- ゴミ箱アイコン（SVG） --}}
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                         </svg>
                     </button>
-                @endcan
+                @endif
             </form>
         </div>
     @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,7 +33,8 @@ Route::middleware('auth')->group(function () {
     Route::post('/menus', [MenuController::class, 'store'])->middleware('auth')->name('menus.store');
 
     // メニューの削除
-    Route::delete('/menus/{menu}', [MenuController::class, 'destroy'])->middleware('can:admin')->name('menus.destroy');
+    // Route::delete('/menus/{menu}', [MenuController::class, 'destroy'])->middleware('can:admin')->name('menus.destroy');
+    Route::delete('/menus/{menu}', [MenuController::class, 'destroy'])->middleware('auth')->name('menus.destroy');
 
     // スロット画面の表示
     Route::get('/', [SlotController::class, 'index'])


### PR DESCRIPTION
仕様を次のように変更することで認可設計の矛盾を解消
`登録メニューの削除は
・ログインしているユーザー本人
・管理者権限を持つユーザー
この場合を削除可能とする
`

よって、`管理者権限を持つユーザーは`登録メニュー一覧で
`全ユーザーのメニューを表示し、メニュー登録者の名前も表示することにした`


①indexメソッドの修正
---
MenuController.phpのindex()を変更することで
管理者：全メニューを取得し表示させる
一般ユーザー：自分のメニューのみ表示

②bladeファイルの修正で登録者名を表示
---
list-items.blade.php
管理者権限のユーザーのみ登録メニュー一覧表示で登録者名が表示されるようにした

③ルートの修正
---
web.php
削除ルートに対して
修正前：「管理者しか通さない」
修正後：ひとまず「ログインすればコントローラーまで通す」
（後述のdestroyメソッドまで通すが、その中で「本人か管理者か」を判断）

④destroyメソッドの修正
---
MenuController.php
「本人である」または「管理者である」のいずれかであれば削除を許可し、
そうでなければ拒否するロジックを追加

⑤bladeファイルの修正で削除ボタンの制御
---
現状の仕様だとあまり関係ないが今後、登録メニューの表示を全ユーザー分見られるように
した場合、自分のメニューは削除がアイコン押せる、自身が登録したメニューでない場合は
押せないようにした

動作チェック
---
[☑️] 一般ユーザーA でログイン：自分のメニューのゴミ箱が動くか？

[☑️] 管理者（admin） でログイン：自分以外の全メニューのゴミ箱が動くか？

[☑️] 一般ユーザーA が、URLの書き換えなどで ユーザーBのメニュー を消そうとした時、コントローラーで阻止されるか？

最後のチェックは次のように実施
**1. 下準備（IDの確認）**
ユーザーBでログインし、適当なメニュー（例：IDが 15 の「オムライス」）があることを確認。

ログアウトして、一般ユーザーA（管理者ではない人）でログインし直す。

**2. ブラウザの「検証モード」を使う**
自分のメニューの「ゴミ箱ボタン」を右クリックし、**「検証」**を選択する。

HTMLコードが表示されるので、その周辺の <form> タグを探し
HTML
`<form action="http://localhost/menus/10" method="POST" class="delete-menu-form">
`この menus/10（自分のID）となっている部分をダブルクリックして、menus/15（ユーザーBのID）に書き換えて Enter 。

**3. 実行して結果を見る**
そのまま、中身を書き換えたそのボタンをクリックして削除を実行してください。

期待する結果:
削除されずに、元のページ（または指定したリダイレクト先）に戻ってくる。

画面に「削除する権限がありません。」というエラーメッセージが表示される。

データベースを確認しても、ユーザーBの「オムライス」が消えていない。