### PR TITLE
MealRecordController::selectDestroy() の入力検証と HTTP メソッド #7

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -120,26 +120,47 @@ class MealRecordController extends Controller
 
     // 保存した献立削除処理
     public function selectDestroy(Request $request) {
-            $ids = $request->input('ids');
+        // バリデーション（不正なデータが来るのを防ぐ）
+        $validated = $request->validate([
+            'ids'   => 'required|array|min:1',      //idsは必須、配列形式、1つ以上
+            'ids.*' => 'integer',                       //配列の中身はすべて数字
+        ]);
 
-            if(!$ids) {
-                return response()->json([
-                    'message' => 'IDがありません。'
-                ], 400);
-            }
+        // 削除の実行（自分のデータ、かつ指定されたIDのみ）
+        // $deletedには実際に削除した件数が返ってくる
+        $deleted = MealRecord::where('user_id', Auth::id())
+                                ->whereIn('id', $validated['ids'])
+                                ->delete();
 
-            MealRecord::where('user_id', Auth::id())->whereIn('id', $ids)->delete();
+        session()->flash('message', "{$deleted}件の献立を削除しました。");
+        session()->flash('type', 'success');
+
+        return response()->json([
+                'message' => "{$deleted}件 of meal records deleted."
+        ], 200);
+
+
+            // $ids = $request->input('ids');
+
+            // バリデーションのおかげで↓のコードは不要
+            // if(!$ids) {
+            //     return response()->json([
+            //         'message' => 'IDがありません。'
+            //     ], 400);
+            // }
+
+            // MealRecord::where('user_id', Auth::id())->whereIn('id', $ids)->delete();
 
             // return redirect()->route('meal_records.index')->with([
             //     'message' => count($request->ids) . '件の献立を削除しました。',
             //     'type' => 'danger',
             // ]);
-            session()->flash('message', count($ids) . '件の献立を削除しました。');
-            session()->flash('type', 'danger');
+            // session()->flash('message', count($ids) . '件の献立を削除しました。');
+            // session()->flash('type', 'danger');
 
-            return response()->json([
-                'message' => '削除成功'
-            ], 200);
+            // return response()->json([
+            //     'message' => '削除成功'
+            // ], 200);
 
     }
 }

--- a/resources/js/meal-record.js
+++ b/resources/js/meal-record.js
@@ -33,8 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     btnText: '削除する',
                     action: async() => {
                         try {
-                            const response = await axios.post('/meal-records/select-delete', {
-                                ids: selectedIds,
+                            // const response = await axios.post('/meal-records/select-delete', {
+                            const response = await axios.delete('/meal-records/select-delete', {
+                                data: {
+                                    ids: selectedIds,
+                                }
                             });
 
                             if(response.status === 200) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,7 +45,8 @@ Route::middleware('auth')->group(function () {
     Route::post('/meal-records', [MealRecordController::class, 'store'])->middleware('auth');
 
     // 保存した献立の削除
-    Route::post('/meal-records/select-delete', [MealRecordController::class, 'selectDestroy'])->middleware('auth');
+    // Route::post('/meal-records/select-delete', [MealRecordController::class, 'selectDestroy'])->middleware('auth');
+    Route::delete('/meal-records/select-delete', [MealRecordController::class, 'selectDestroy'])->middleware('auth')->name('meal_records.select_destroy');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
①selectDestroy()にバリデーションを追加
---
「ids は必ず配列で、その中身は全部数字じゃなきゃダメ！」だよ、というバリデーションを追加

②HTTPメソッドの変更
---
・献立履歴の削除で削除で使用していたPOSTメソッドをDELETEに変更
meal-record.js
・axiosのところもpostからdeleteに変更
```
const response = await axios.delete('/meal-records/select-delete', {
                                data: {
                                    ids: selectedIds,
                                }
                            });
```
=>誰が見ても「この通信はデータを消すためのものだな」と一目でわかるようになった。
「一貫性」や「RESTful」を実現

③delete()の戻り値を活用
---
修正前：count($ids)　→　ユーザーが消したい数
修正後：delete()の戻り値　→　システムが実際に消した数
=>正確な削除件数を保証