### PR TITLE
MealRecordController::store() のステータスコード 442 は存在しない #9

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -40,7 +40,7 @@ class MealRecordController extends Controller
         if($exists) {
             return response()->json([
                 'message' => '本日の献立はすでに保存済みです。'
-            ], 442);
+            ], 409);
         }
 
         // 2. バリデーション

--- a/resources/js/slot.js
+++ b/resources/js/slot.js
@@ -281,7 +281,7 @@ if(saveBtn) {
                         } catch (error) {
                             console.error('保存エラー', error);
 
-                            if(error.response && error.response.status === 442) {
+                            if(error.response && error.response.status === 409) {
                                 // alert(error.response.data.message);
                                 window.dispatchEvent(new CustomEvent('alert-message', {
                                     detail: {message: error.response.data.message}


### PR DESCRIPTION
・なぜ「442」としていたのかが自分自身でも分からないのですが、本件においては
サーバーの状態とブラウザからのリクエストがぶつかっている、コンフリクトしているということを理解・納得し
「409」に変更しました。