### PR TITLE
マジックナンバーの type_id（1/2/3）が全層に散らばっています #11

### DIFF
--- a/app/Enums/MenuType.php
+++ b/app/Enums/MenuType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+/**
+ * メニュージャンルのタイプを定義するEnum
+ */
+enum MenuType: int {
+    case Main = 1;      //主菜
+    case SideA = 2;     //副菜A
+    case SideB = 3;     //副菜B
+}

--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\MenuType;
 use App\Models\MealRecord;
 use App\Models\MealRecordItem;
 use Illuminate\Http\Request;
@@ -49,15 +50,15 @@ class MealRecordController extends Controller
         $validated = $request->validate([
             'main_dish_id' => [
                 'required', Rule::exists('menus', 'id')
-                ->where('user_id', $userId)->where('type_id', 1)
+                ->where('user_id', $userId)->where('type_id', MenuType::Main->value)
             ],
             'sub_dish_a_id' => [
                 'required', Rule::exists('menus', 'id')
-                ->where('user_id', $userId)->where('type_id', 2)
+                ->where('user_id', $userId)->where('type_id', MenuType::SideA->value)
             ],
             'sub_dish_b_id' => [
                 'required', Rule::exists('menus', 'id')
-                ->where('user_id', $userId)->where('type_id', 3)
+                ->where('user_id', $userId)->where('type_id', MenuType::SideB->value)
             ], [
                 'main_dish_id.exists' => '選択された主菜は無効です。',
                 'main_dish_a_id.exists' => '選択された副菜Aは無効です。',
@@ -85,15 +86,15 @@ class MealRecordController extends Controller
                 // ここで DB上のカラム名 'menu_id' と 'type_id' にマッピングします
                 $items = [
                     [
-                        'type_id' => 1, // 主菜
+                        'type_id' => MenuType::Main->value, // 主菜
                         'menu_id' => $validated['main_dish_id']
                     ],
                     [
-                        'type_id' => 2, // 副菜A
+                        'type_id' => MenuType::SideA->value, // 副菜A
                         'menu_id' => $validated['sub_dish_a_id']
                     ],
                     [
-                        'type_id' => 3, // 副菜B
+                        'type_id' => MenuType::SideB->value, // 副菜B
                         'menu_id' => $validated['sub_dish_b_id']
                     ],
                 ];

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\MenuType;
 use App\Models\Menu;
 use App\Models\Type;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rules\Enum;
 
 class MenuController extends Controller
 {
@@ -21,7 +23,12 @@ class MenuController extends Controller
         // 1.バリデーション（入力チェック）
         $request->validate([
             'menu_name' => 'required|string|max:255',
-            'type_id' => 'required|integer|exists:types,id',
+            'type_id' => [
+                'required',
+                'integer',
+                'exists:types,id',
+                new Enum(MenuType::class) // Enumで定義した値(1,2,3)以外は弾くことで厳しくチェック
+            ],
             'image_path' => 'nullable|image|mimes:png,jpg,jpeg,gif|max:2048',
             'recipe_url' => 'nullable|url|max:255',
             'memo' => 'nullable|string|max:1000',
@@ -114,7 +121,7 @@ class MenuController extends Controller
         // 4. 一覧画面に戻す
         return redirect()->route('menus.index')->with([
             'message' => 'メニューを削除しました。',
-            'type' => 'danger',
+            'type' => 'success',
         ]);
     }
 }

--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\MenuType;
 use App\Models\Menu;
 use Illuminate\Http\Request;
 
@@ -13,10 +14,15 @@ class SlotController extends Controller
         $menus = Menu::where('user_id', auth()->id())->get();
 
         // 2. 各料理タイプの登録件数を集計
+        // $counts = [
+        //     'main' => $menus->where('type_id', 1)->count(),
+        //     'side_a' =>  $menus->where('type_id', 2)->count(),
+        //     'side_b' =>  $menus->where('type_id', 3)->count(),
+        // ];
         $counts = [
-            'main' => $menus->where('type_id', 1)->count(),
-            'side_a' =>  $menus->where('type_id', 2)->count(),
-            'side_b' =>  $menus->where('type_id', 3)->count(),
+            'main' => $menus->where('type_id', MenuType::Main->value)->count(),
+            'side_a' =>  $menus->where('type_id', MenuType::SideA->value)->count(),
+            'side_b' =>  $menus->where('type_id', MenuType::SideB->value)->count(),
         ];
 
         // 3. 全てのタイプが3つ以上登録されているかを判定

--- a/resources/js/slot.js
+++ b/resources/js/slot.js
@@ -9,11 +9,15 @@ const activeTimelines = {
     sub_b: null,
 }
 
+console.log(window.MENU_TYPES.MAIN);
+console.log(window.MENU_TYPES.SIDE_A);
+console.log(window.MENU_TYPES.SIDE_B);
+
 // 当選したメニューを保持するオブジェクト（グローバルに近い場所で定義）
 let selectedResults = {
-    1: null, // 主菜
-    2: null, // 副菜A
-    3: null  // 副菜B
+    [window.MENU_TYPES.MAIN]: null, // 主菜
+    [window.MENU_TYPES.SIDE_A]: null, // 副菜A
+    [window.MENU_TYPES.SIDE_B]: null  // 副菜B
 };
 
 const saveBtn = document.getElementById('save-button');
@@ -24,9 +28,9 @@ const resultSubB = document.getElementById('result-sub-b');
 
 window.toggleSlot = function(type, isRolling) {
     const idMap = {
-        1: 'slot-main',
-        2: 'slot-sub-a',
-        3: 'slot-sub-b'
+        [window.MENU_TYPES.MAIN]: 'slot-main',
+        [window.MENU_TYPES.SIDE_A]: 'slot-sub-a',
+        [window.MENU_TYPES.SIDE_B]: 'slot-sub-b'
     };
 
     const ul = document.getElementById(idMap[type]);
@@ -40,7 +44,7 @@ window.toggleSlot = function(type, isRolling) {
         updateSaveButtonState();
 
         // 【追加】回転開始時に、該当するスロットの表示をクリアする
-        const resEl = type === 1 ? resultMain : (type === 2 ? resultSubA : resultSubB);
+        const resEl = type === window.MENU_TYPES.MAIN ? resultMain : (type === window.MENU_TYPES.SIDE_A ? resultSubA : resultSubB);
         if (resEl) resEl.textContent = '...';
 
         const items = allMenus.filter(m => m.type_id === type);
@@ -89,7 +93,11 @@ window.toggleSlot = function(type, isRolling) {
         if (resEl) resEl.textContent = wonMenu.name;
 
         // 2. 中央結果エリアの更新
-        const displayIdMap = { 1: 'display-main', 2: 'display-sub-a', 3: 'display-sub-b' };
+        const displayIdMap = {
+            [window.MENU_TYPES.MAIN]: 'display-main',
+            [window.MENU_TYPES.SIDE_A]: 'display-sub-a',
+            [window.MENU_TYPES.SIDE_B]: 'display-sub-b',
+        };
         const displaySpan = document.getElementById(displayIdMap[type]);
         if (displaySpan) {
             displaySpan.textContent = wonMenu.name;
@@ -222,9 +230,9 @@ if(saveBtn) {
         // 3. 送信データの作成
         console.log("保存処理を開始します...");
         const postData = {
-            main_dish_id: selectedResults[1].id,
-            sub_dish_a_id: selectedResults[2].id,
-            sub_dish_b_id: selectedResults[3].id,
+            main_dish_id: selectedResults[window.MENU_TYPES.MAIN].id,
+            sub_dish_a_id: selectedResults[window.MENU_TYPES.SIDE_A].id,
+            sub_dish_b_id: selectedResults[window.MENU_TYPES.SIDE_B].id,
         };
 
         // 自作の確認モーダルを呼び出す

--- a/resources/views/meal_records/index.blade.php
+++ b/resources/views/meal_records/index.blade.php
@@ -24,10 +24,10 @@
                     <tbody class="bg-white divide-y divide-black">
                         @foreach ($mealRecords as $record)
                             @php
-                                // 1. 各タイプを事前に抽出（リレーション名は mealRecordItems である前提です）
-                                $main = $record->mealRecodItems->where('type_id', 1)->first();
-                                $sideA = $record->mealRecodItems->where('type_id', 2)->first();
-                                $sideB = $record->mealRecodItems->where('type_id', 3)->first();
+                                // 1. 各タイプを事前に抽出（リレーション名は mealRecordItems）
+                                $main = $record->mealRecodItems->where('type_id', \App\Enums\MenuType::Main->value)->first();
+                                $sideA = $record->mealRecodItems->where('type_id', \App\Enums\MenuType::SideA->value)->first();
+                                $sideB = $record->mealRecodItems->where('type_id', \App\Enums\MenuType::SideB->value)->first();
                             @endphp
                             <tr>
                                 <td class="px-6 py-4 text-center border-r border-black">

--- a/resources/views/menus/create.blade.php
+++ b/resources/views/menus/create.blade.php
@@ -21,9 +21,9 @@
                     {{-- ジャンル --}}
                     <div>
                         <label for="">ジャンル※</label>
-                        <input type="radio" name="type_id" value="1" {{old('type_id') == 1 ? 'checkd' : ''}}>メイン
-                        <input type="radio" name="type_id" value="2" {{old('type_id') == 2 ? 'checkd' : ''}}>副菜A
-                        <input type="radio" name="type_id" value="3" {{old('type_id') == 3 ? 'checkd' : ''}}>副菜B
+                        <input type="radio" name="type_id" value="{{ \App\Enums\MenuType::Main->value }}" {{old('type_id') == \App\Enums\MenuType::Main->value ? 'checked' : ''}}>メイン
+                        <input type="radio" name="type_id" value="{{ \App\Enums\MenuType::SideA->value }}" {{old('type_id') == \App\Enums\MenuType::SideA->value ? 'checked' : ''}}>副菜A
+                        <input type="radio" name="type_id" value="{{ \App\Enums\MenuType::SideB->value }}" {{old('type_id') == \App\Enums\MenuType::SideB->value ? 'checked' : ''}}>副菜B
                         @error('type_id')
                             <p class="text-red-500">{{ $message }}</p>
                         @enderror

--- a/resources/views/slot/index.blade.php
+++ b/resources/views/slot/index.blade.php
@@ -156,6 +156,14 @@
                 </div> --}}
         </div>
     @push('scripts')
+        {{-- JavaScript側にPHPのEnum値を定数として渡す --}}
+        <script>
+            window.MENU_TYPES = {
+                MAIN: {{ \App\Enums\MenuType::Main->value }},
+                SIDE_A: {{ \App\Enums\MenuType::SideA->value }},
+                SIDE_B: {{ \App\Enums\MenuType::SideB->value }}
+            };
+        </script>
         @vite('resources/js/slot.js')
     @endpush
 </x-app-layout>


### PR DESCRIPTION
①Enumファイルの作成
---
app\Enums\MenuType.php　を作成しそちらで`メニュージャンルのタイプを定義するEnum`を管理

②各ファイルで使われていたマジックナンバーを潰す
---
・MealRecordController.php
・SlotController.php
・meal_records\index.blade.php
・menus\create.blade.php
・slot\index.blade.php　→　JavaScriptにEnumデータを送るために記述
・slot.js