### PR TITLE
リレーションメソッド名の typo mealRecodItems #13

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -18,7 +18,7 @@ class MealRecordController extends Controller
         // 1. ログイン中のユーザーの献立だけを取得する
         // 2. その際、紐づいている明細（MealRecordItems）も一緒に読み込む
         $mealRecords = Auth::user()->mealRecords()
-            ->with('mealRecodItems.menu')
+            ->with('mealRecordItems.menu')
             ->orderBy('date', 'desc')
             ->get();
 

--- a/app/Models/MealRecord.php
+++ b/app/Models/MealRecord.php
@@ -15,7 +15,7 @@ class MealRecord extends Model
     ];
 
     // リレーション：この記録には、複数の料理（アイテム）が含まれる
-    public function mealRecodItems(): HasMany
+    public function mealRecordItems(): HasMany
     {
         return $this->hasMany(MealRecordItem::class);
     }

--- a/app/Models/Type.php
+++ b/app/Models/Type.php
@@ -15,7 +15,7 @@ class Type extends Model
     }
 
     // リレーション：一つのタイプは、複数の献立記録明細をもつ
-    public function mealRecodItems(): HasMany
+    public function mealRecordItems(): HasMany
     {
         return $this->hasMany(MealRecordItem::class);
     }

--- a/resources/views/meal_records/index.blade.php
+++ b/resources/views/meal_records/index.blade.php
@@ -25,9 +25,9 @@
                         @foreach ($mealRecords as $record)
                             @php
                                 // 1. 各タイプを事前に抽出（リレーション名は mealRecordItems）
-                                $main = $record->mealRecodItems->where('type_id', \App\Enums\MenuType::Main->value)->first();
-                                $sideA = $record->mealRecodItems->where('type_id', \App\Enums\MenuType::SideA->value)->first();
-                                $sideB = $record->mealRecodItems->where('type_id', \App\Enums\MenuType::SideB->value)->first();
+                                $main = $record->mealRecordItems->where('type_id', \App\Enums\MenuType::Main->value)->first();
+                                $sideA = $record->mealRecordItems->where('type_id', \App\Enums\MenuType::SideA->value)->first();
+                                $sideB = $record->mealRecordItems->where('type_id', \App\Enums\MenuType::SideB->value)->first();
                             @endphp
                             <tr>
                                 <td class="px-6 py-4 text-center border-r border-black">


### PR DESCRIPTION
下記ファイルでタイポの修正を実施
---
・MealRecordController.php
・MealRecord.php
・Type.php
・meal_records\index.blade.php
