### PR TITLE
一覧画面にページネーションがありません #17

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -22,7 +22,8 @@ class MealRecordController extends Controller
         $mealRecords = Auth::user()->mealRecords()
             ->with('mealRecordItems.menu')
             ->orderBy('date', 'desc')
-            ->get();
+            // ->get();
+            ->paginate(10);     //1ページ20件
 
         // 3. ビュー（画面）にデータを渡す
         return view('meal_records.index', compact('mealRecords'));

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -90,13 +90,15 @@ class MenuController extends Controller
             // 管理者の場合：すべてのユーザーのメニューを取得
             $menus = Menu::with(['user', 'type'])
                         ->orderBy('created_at', 'desc')
-                        ->get();
+                        // ->get();
+                        ->paginate(10);
         } else {
             // 一般ユーザーの場合：自分のメニューのみ取得
             $menus = Menu::where('user_id', $user->id)
                         ->with('type')
                         ->orderBy('created_at', 'desc')
-                        ->get();
+                        // ->get();
+                         ->paginate(10);
         }
 
         // // 1. ログインユーザーのメニューのみを取得

--- a/resources/views/meal_records/index.blade.php
+++ b/resources/views/meal_records/index.blade.php
@@ -50,6 +50,10 @@
                     </tbody>
                 </table>
             </div>
+        {{-- ページネーション --}}
+        <div class="mt-6 px-2">
+            {{ $mealRecords->links() }}
+        </div>
         {{-- ナビゲーション --}}
                 <x-sub-navigation current="meal-records" />
         </div>

--- a/resources/views/menus/index.blade.php
+++ b/resources/views/menus/index.blade.php
@@ -2,7 +2,9 @@
     {{-- 1. x-dataで「今どのタブを開いているか」という状態を定義 --}}
     {{-- session('show_create')があれば登録画面、なければ一覧を初期表示にする --}}
     <div
-        x-data="{ tab: '{{ session('type') === 'success' ? 'list' : 'create' }}' }"
+        x-data="{
+            tab: '{{ (request()->has('page') || session('type') === 'success') ? 'list' : 'create' }}' }"
+            {{-- tab: '{{ (request('tab') === 'list' || request()->has('page') || session('type') === 'success') ? 'list' : 'create' }}' }" --}}
         {{-- class="max-w-4xl mx-auto p-6" --}}
         class="relative z-10 w-[80%] mx-auto bg-[#fee5a5] rounded-[2em] shadow-2xl p-8 md:p-10 text-center"
     >
@@ -17,14 +19,16 @@
             {{-- 2. タブのスイッチ --}}
             <div class="flex justify-start space-x-8 border-b border-gray-200 mb-8">
                 <button
-                    @click="tab = 'create'"
+                    @click="tab = 'create';
+                        window.history.replaceState(null, '', window.location.pathname);
+                    "
                     :class="tab === 'create' ? 'border-b-2 border-orange-500 text-orange-600 font-bold' : 'text-gray-400' "
                     class="pb-2 px-4 transition-all"
                 >
                     メニュー登録
                 </button>
                 <button
-                    @click="tab = 'list'"
+                    @click="window.location.href = '{{ route('menus.index') }}?page=1'"
                     :class="tab === 'list' ? 'border-b-2 border-orange-500 text-orange-600 font-bold' : 'text-gray-400' "
                     class="pb-2 px-4 transition-all"
                 >
@@ -45,9 +49,13 @@
             <div x-show="tab === 'list'" x-cloak>
                 <div class="bg-white p-8 rounded-2xl shadow-sm">
                     <p class="text-orange-700 font-bold mb-6 text-[18px]">
-                        登録件数: {{ $menus->count() }}件
+                        登録件数: {{ $menus->total() }}件
                     </p>
                     @include('menus.partials.list-items')   {{--別ファイルで管理--}}
+                </div>
+                {{-- ページネーション --}}
+                <div class="mt-6 px-2">
+                    {{ $menus->links() }}
                 </div>
             </div>
         {{-- ナビゲーション --}}


### PR DESCRIPTION
①MealRecordController.php
---
・get()からpaginate()を使用
・meal_records/index.blade.phpでページネーションを表示

②MenuController.php
---
・get()からpaginate()を使用
・menus/index.blade.phpでページネーションを表示
　→タブの切り替えで「メニュー登録」「登録メニュー一覧」を実現しているが
　　ページネーションの動作に伴い、URLの変更なども追加