### PR TITLE
meal_record_items の menu_id が cascadeOnDelete になっている #19

### DIFF
--- a/app/Models/MealRecordItem.php
+++ b/app/Models/MealRecordItem.php
@@ -20,7 +20,7 @@ class MealRecordItem extends Model
     // リレーション：この明細は、ひとつのメニューを持つ
     public function menu(): BelongsTo
     {
-        return $this->belongsTo(Menu::class);
+        return $this->belongsTo(Menu::class)->withTrashed();
     }
 
     // リレーション：この明細は、ひとつの料理タイプ（メイン/副菜など）を持つ

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -6,11 +6,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Menu extends Model
 {
     //
     use HasFactory;
+    use SoftDeletes;
 
     protected $fillable = [
         'user_id',

--- a/database/migrations/2026_05_06_114008_add_soft_deletes_to_menus_table.php
+++ b/database/migrations/2026_05_06_114008_add_soft_deletes_to_menus_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            // delete_at カラムを追加
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            // ロールバック時にカラムを削除
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_05_06_114132_update_foreign_key_on_meal_record_items_table.php
+++ b/database/migrations/2026_05_06_114132_update_foreign_key_on_meal_record_items_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('meal_record_items', function (Blueprint $table) {
+            // 1. 今ある外部キー制約を削除
+            // 制約めいは「テーブル名_カラム名_foreign」
+            $table->dropForeign(['menu_id']);
+
+            // 2. 新しい制約を作る
+            // cascadeOnDeleteを外すと、親が消えても子が消えなくなる(restrict)
+            $table->foreign('menu_id')->references('id')->on('menus')->onDelete('restrict');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('meal_record_items', function (Blueprint $table) {
+            $table->dropForeign(['menu_id']);
+
+            // ロールバック時は元の cascadeOnDelete に戻す
+            $table->foreign('menu_id')->references('id')->on('menus')->cascadeOnDelete();
+
+        });
+    }
+};


### PR DESCRIPTION
①データベース構造の変更（マイグレーション）
---
**「物理的にデータを消す設定」から「消してもデータが残る設定」へ、2つのマイグレーションで土台を作成。**

（1）menus テーブルに削除フラグを追加
softDeletes() を実行し、deleted_at カラムを追加
=>レコードを完全に消去せず「削除済み」という印をつけるだけで保持できるようになりました。

（2）meal_record_items の外部キー制約を張り直し
一度、古い制約（cascadeOnDelete）を dropForeign で切り離す
=>親（メニュー）が消えても子が消えない新しい制約（restrict）を繋ぎ直す

②モデルのロジック修正（Laravel側の設定）
---
**①により、データベースの準備はできても、Laravel側でsoftDeletesが使えるように設定する必要がある。**

（1）Menu モデルで SoftDeletes を有効化
use SoftDeletes トレイトを追加
=>$menu->delete() を実行した際、DBから消さずに deleted_at に現在時刻を書き込む「論理削除」が動く

（2）MealRecordItem モデルのリレーションを拡張
menu() リレーションに withTrashed() を追加
=>【！今回の重要ポイント】削除済みのメニューであっても、履歴画面からはそのデータを見つけ出して表示できる

③bladeファイルの修正
---
何かしらの原因で論理削除の動作に不具合があった場合を考慮し削除されたメニュー表示の「_ 」は残す
=>「 _ 」から修正し「（削除済み）」に変更（削除されたことを分かりやすく伝える方法を選択）

④動作の最終確認
---
（1）メニュー削除時：管理画面（メニュー一覧）からは正しく消える
（2）データベース内にはデータが保持されている
（3）履歴表示時：
　--以前：「削除されたメニュー」は表示されず 「-」 表示となっていたが、
　--今回：正しいメニュー名が表示され続ける
（4）整合性：献立履歴そのもの（親）を消した場合は、その中身（子）も連動して消える設定を維持し、ゴミデータが残らないように配慮。
