### PR TITLE
User::menu() の命名が単数形 #21

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -55,8 +55,15 @@ class MenuController extends Controller
         }
 
         // 3. データベースに保存
-        Menu::create([
-            'user_id'       => Auth::id(),
+        // Menu::create([
+        //     'user_id'       => Auth::id(),
+        //     'name'          => $validated['menu_name'],
+        //     'type_id'       => $validated['type_id'],
+        //     'image_path'    => $imagePath,
+        //     'recipe_url'    => $validated['recipe_url'] ?? null,
+        //     'memo'          => $validated['memo'] ?? null,
+        // ]);
+        Auth::user()->menus()->create([
             'name'          => $validated['menu_name'],
             'type_id'       => $validated['type_id'],
             'image_path'    => $imagePath,
@@ -94,11 +101,15 @@ class MenuController extends Controller
                         ->paginate(10);
         } else {
             // 一般ユーザーの場合：自分のメニューのみ取得
-            $menus = Menu::where('user_id', $user->id)
+            // $menus = Menu::where('user_id', $user->id)
+            //             ->with('type')
+            //             ->orderBy('created_at', 'desc')
+            //             // ->get();
+            //              ->paginate(10);
+            $menus = $user->menus()
                         ->with('type')
                         ->orderBy('created_at', 'desc')
-                        // ->get();
-                         ->paginate(10);
+                        ->paginate(10);
         }
 
         // // 1. ログインユーザーのメニューのみを取得

--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -5,13 +5,15 @@ namespace App\Http\Controllers;
 use App\Enums\MenuType;
 use App\Models\Menu;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class SlotController extends Controller
 {
     //
     public function index() {
         // 1. ログインユーザーのメニューを「メイン」「副菜A」「副菜B」に分けて取得する
-        $menus = Menu::where('user_id', auth()->id())->get();
+        // $menus = Menu::where('user_id', auth()->id())->get();
+        $menus = Auth::user()->menus;
 
         // 2. 各料理タイプの登録件数を集計
         // $counts = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,7 +55,8 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     // リレーション：このユーザーは、複数のメニュー登録をもつ
-    public function menu(): HasMany
+    // public function menu(): HasMany
+    public function menus(): HasMany
     {
         return $this->hasMany(Menu::class);
     }

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -17,48 +17,96 @@ class MenuSeeder extends Seeder
         //
         $user = User::where('email', 'test@example.com')->first();
 
-        Menu::create([
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => 'ハンバーグ',
+        //     'type_id' => 1,
+        //     'recipe_url' => 'https://recipe.example.com/hamburg',
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => 'ミートソーススパゲッティ',
+        //     'type_id' => 1,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => '肉じゃが',
+        //     'type_id' => 1,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => '無限ピーマン',
+        //     'type_id' => 2,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => '彩り温野菜サラダ',
+        //     'type_id' => 3,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => 'ほうれん草のお浸し',
+        //     'type_id' => 2,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => '冷奴',
+        //     'type_id' => 3,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => '湯豆腐',
+        //     'type_id' => 3,
+        // ]);
+        // $user->menus()->create([
+        //     'user_id' => $user->id,
+        //     'name' => 'ポテトサラダ',
+        //     'type_id' => 2,
+        //     'recipe_url' => 'https://recipe.example.com/potatosalada',
+
+        // ]);
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => 'ハンバーグ',
             'type_id' => 1,
             'recipe_url' => 'https://recipe.example.com/hamburg',
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => 'ミートソーススパゲッティ',
             'type_id' => 1,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => '肉じゃが',
             'type_id' => 1,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => '無限ピーマン',
             'type_id' => 2,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => '彩り温野菜サラダ',
             'type_id' => 3,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => 'ほうれん草のお浸し',
             'type_id' => 2,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => '冷奴',
             'type_id' => 3,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => '湯豆腐',
             'type_id' => 3,
         ]);
-        Menu::create([
+        $user->menus()->create([
             'user_id' => $user->id,
             'name' => 'ポテトサラダ',
             'type_id' => 2,

--- a/resources/views/meal_records/index.blade.php
+++ b/resources/views/meal_records/index.blade.php
@@ -37,13 +37,13 @@
                                     {{str_replace('-', '/', $record->date)}}
                                 </td>
                                 <td class="px-6 py-4 text-left whitespace-nowrap text-sm font-medium text-gray-700 border-r border-black">
-                                    {{$main->menu->name ?? '_'}}
+                                    {{$main->menu->name ?? '（削除済み）'}}
                                 </td>
                                 <td class="px-6 py-4 text-left whitespace-nowrap text-sm font-medium text-gray-700 border-r border-black">
-                                    {{$sideA->menu->name ?? '_'}}
+                                    {{$sideA->menu->name ?? '（削除済み）'}}
                                 </td>
                                 <td class="px-6 py-4 text-left whitespace-nowrap text-sm font-medium text-gray-700 border-r border-black">
-                                    {{$sideB->menu->name ?? '_'}}
+                                    {{$sideB->menu->name ?? '（削除済み）'}}
                                 </td>
                             </tr>
                         @endforeach


### PR DESCRIPTION
①/Users/taekoohama/Step26-my-portfolio/app/Models/User.php
---
`public function menus(): HasMany
    {
        return $this->hasMany(Menu::class);
    }`

=>「menus()」と複数形の名前に修正
=>  コードを読んだだけで「このメソッドはメニューのコレクション（塊）を返すんだな」と一瞬で判断できるようなった

②リレーションの利用
---
（1）データの「取得」をスマートにする
Menu::where('user_id', auth()->id())->get()
↓
Auth::user()->menus

「Menuテーブル全体から自分のIDを探す」というSQL的な考え方から、
「ユーザー(自分)の持ち物(menus)を取り出す」という直感的な書き方に変える
=>  user_id というカラム名を意識しなくて済むようになり、タイピングミスによるバグを防げるようになった

（2）データの「保存」を安全にする
Menu::create(['user_id' => $user->id, ...])
↓
$user->menus()->create([...])

リレーションのメソッド（カッコあり）を経由することで、Laravelが自動的に user_id を
セットしてくれる。
=>  user_id の指定漏れが物理的に発生しなくなり、コードも短くなった