### PR TITLE
ビュー内の @php ブロックで明細を抽出している #23

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -16,16 +16,31 @@ use Illuminate\Validation\Rule;
 class MealRecordController extends Controller
 {
     //献立の一覧表示をする
-    public function index() {
-        // 1. ログイン中のユーザーの献立だけを取得する
-        // 2. その際、紐づいている明細（MealRecordItems）も一緒に読み込む
-        $mealRecords = Auth::user()->mealRecords()
-            ->with('mealRecordItems.menu')
-            ->orderBy('date', 'desc')
-            // ->get();
-            ->paginate(10);     //1ページ20件
+    // public function index() {
+    //     // 1. ログイン中のユーザーの献立だけを取得する
+    //     // 2. その際、紐づいている明細（MealRecordItems）も一緒に読み込む
+    //     $mealRecords = Auth::user()->mealRecords()
+    //         ->with('mealRecordItems.menu')
+    //         ->orderBy('date', 'desc')
+    //         // ->get();
+    //         ->paginate(10);     //1ページ20件
 
-        // 3. ビュー（画面）にデータを渡す
+    //     // 3. ビュー（画面）にデータを渡す
+    //     return view('meal_records.index', compact('mealRecords'));
+    // }
+    public function index() {
+        // 1. ログインユーザーの献立だけを取得する
+        // 2. その際、主菜・副菜A・副菜Bをそれぞれの窓口（作成したリレーション）経由で一括読み込みする
+        $mealRecords = Auth::user()->mealRecords()
+            ->with([
+                'mainDish.menu',
+                'sideDishA.menu',
+                'sideDishB.menu',
+            ])
+            ->orderBy('date', 'desc')
+            ->paginate(10);
+
+        // 3. ビューにデータを渡す
         return view('meal_records.index', compact('mealRecords'));
     }
 

--- a/app/Models/MealRecord.php
+++ b/app/Models/MealRecord.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\MenuType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -25,4 +26,21 @@ class MealRecord extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    // 主菜の明細を取得
+    public function mainDish()
+    {
+        return $this->hasOne(MealRecordItem::class)->where('type_id', MenuType::Main->value);
+    }
+    // 副菜Aの明細を取得
+    public function sideDishA()
+    {
+        return $this->hasOne(MealRecordItem::class)->where('type_id', MenuType::SideA->value);
+    }
+    // 副菜Bの明細を取得
+    public function sideDishB()
+    {
+        return $this->hasOne(MealRecordItem::class)->where('type_id', MenuType::SideB->value);
+    }
+
 }

--- a/resources/views/meal_records/index.blade.php
+++ b/resources/views/meal_records/index.blade.php
@@ -23,12 +23,12 @@
                     </thead>
                     <tbody class="bg-white divide-y divide-black">
                         @foreach ($mealRecords as $record)
-                            @php
+                            {{-- @php
                                 // 1. 各タイプを事前に抽出（リレーション名は mealRecordItems）
                                 $main = $record->mealRecordItems->where('type_id', \App\Enums\MenuType::Main->value)->first();
                                 $sideA = $record->mealRecordItems->where('type_id', \App\Enums\MenuType::SideA->value)->first();
                                 $sideB = $record->mealRecordItems->where('type_id', \App\Enums\MenuType::SideB->value)->first();
-                            @endphp
+                            @endphp --}}
                             <tr>
                                 <td class="px-6 py-4 text-center border-r border-black">
                                     <input type="checkbox" name="record_ids[]" value="{{$record->id}}" class="record-checkbox rounded border-gray-300 text-yellow-600 focus:ring-yellow-500">
@@ -37,13 +37,16 @@
                                     {{str_replace('-', '/', $record->date)}}
                                 </td>
                                 <td class="px-6 py-4 text-left whitespace-nowrap text-sm font-medium text-gray-700 border-r border-black">
-                                    {{$main->menu->name ?? '（削除済み）'}}
+                                    {{-- {{$main->menu->name ?? '（削除済み）'}} --}}
+                                    {{$record->mainDish?->menu?->name ?? '（削除済み）'}}
                                 </td>
                                 <td class="px-6 py-4 text-left whitespace-nowrap text-sm font-medium text-gray-700 border-r border-black">
-                                    {{$sideA->menu->name ?? '（削除済み）'}}
+                                    {{-- {{$sideA->menu->name ?? '（削除済み）'}} --}}
+                                    {{$record->sideDishA?->menu?->name ?? '（削除済み）'}}
                                 </td>
                                 <td class="px-6 py-4 text-left whitespace-nowrap text-sm font-medium text-gray-700 border-r border-black">
-                                    {{$sideB->menu->name ?? '（削除済み）'}}
+                                    {{-- {{$sideB->menu->name ?? '（削除済み）'}} --}}
+                                    {{$record->sideDishB?->menu?->name ?? '（削除済み）'}}
                                 </td>
                             </tr>
                         @endforeach


### PR DESCRIPTION
①「現場」での仕分けをやめた
---
修正前： Blade（表示現場） で「えーっと、主菜はどれかな？」と `$record->mealRecodItems->where(...)` を使って毎回探し出していた
修正後：Model（データの定義場所） にあらかじめ「主菜専用の窓口」を作ったため、Viewはただ「主菜を見せて」と頼むだけで済むようになった

②「電話の回数」を劇的に減らした
---
修正前：献立が10件あれば、それぞれの主菜・副菜を特定するために何度もデータベースに問い合わせ**（N+1問題）**が発生するリスクがあった
修正後：コントローラーで `with(['mainDish.menu', ...])` を使ったことで、**最初の1回の通信**で必要なデータをすべて積み込んだ状態で View に渡せるようになり、パフォーマンスが向上

④「null」への耐性がついた
---
`?-> `（null安全演算子）を使ったことで、もしデータが欠けている（null）場合でも、画面が真っ白なエラーにならずに ?? '（削除済み）' が表示される、「壊れにくい画面」に