### PR TITLE
Slot 画面の3スロットがコピペで量産されている #25

### DIFF
--- a/resources/views/components/slot-panel.blade.php
+++ b/resources/views/components/slot-panel.blade.php
@@ -1,0 +1,36 @@
+@props(['id', 'label', 'type', 'isReady'])
+
+<div class="space-y-4 w-[calc((100%-48px)/3)]">
+    {{-- <h2 class="text-[#d97706] font-bold text-xl">メイン</h2> --}}
+    <h2 class="text-[#d97706] font-bold text-xl">{{ $label }}</h2>
+    <div x-data="{ rolling: false }" class="space-y-4">
+        <div class="slot-container aspect-square bg-white rounded-2xl border-4 border-[#d97706] overflow-hidden shadow-inner">
+            {{-- ここにJSで生成した<ul><li>が入る --}}
+            {{-- <ul id="slot-main" class="absolute inset-0 m-0 p-0 list-none"></ul> --}}
+            <ul id="{{ $id }}" class="absolute inset-0 m-0 p-0 list-none"></ul>
+            <div class="absolute inset-0 pointer-events-none z-10"
+                style="background: linear-gradient(to bottom,
+                    rgba(0,0,0,0.8) 0%,
+                    rgba(0,0,0,0) 17%,
+                    rgba(0,0,0,0) 83%,
+                    rgba(0,0,0,0.8) 100%
+                );"
+            >
+            </div>
+        </div>
+        {{-- $isReadyがfalseならスタートボタン無効化 --}}
+        <button
+        @if ($isReady)
+            {{-- @click="rolling = !rolling; toggleSlot(1, rolling)" --}}
+            {{-- @click="rolling = !rolling; toggleSlot(window.MENU_TYPES.MAIN, rolling)" --}}
+            @click="rolling = !rolling; toggleSlot({{ $type }}, rolling)"
+        @endif
+            {{-- :class="rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]'" --}}
+            :class="!{{ $isReady ? 'true' : 'false' }} ? 'bg-red-400 cursor-not-allowed opacity-50' : (rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]')"
+            class="w-full py-3 bg-[#fbbf24] hover:bg-[#f59e0b] text-white font-bold rounded-xl shadow-md transition-all active:scale-95"
+        >
+            {{-- <span x-text="rolling ? 'ストップ' : 'スタート'"></span> --}}
+            <span x-text="!{{ $isReady ? 'true' : 'false' }} ? '準備中' : (rolling ? 'ストップ' : 'スタート')"></span>
+        </button>
+    </div>
+</div>

--- a/resources/views/slot/index.blade.php
+++ b/resources/views/slot/index.blade.php
@@ -1,4 +1,13 @@
 <x-app-layout>
+    {{-- この画面（レイアウト内）で使うデータを定義 --}}
+    @php
+        $slots = [
+            ['id' => 'slot-main', 'label' => 'メイン', 'type' => 'window.MENU_TYPES.MAIN'],
+            ['id' => 'slot-sub-a', 'label' => '副菜A', 'type' => 'window.MENU_TYPES.SIDE_A'],
+            ['id' => 'slot-sub-b', 'label' => '副菜B', 'type' => 'window.MENU_TYPES.SIDE_B'],
+        ];
+    @endphp
+
         {{-- メニュー登録件数が足りない時のメッセージ --}}
         @if (!$isReady)
             <div class="absolute top-[40%] left-[50%] translate-x-[-50%] z-20 w-full max-w-4xl mb-6 bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4 rounded shadow-md" role="alert">
@@ -24,115 +33,14 @@
             {{-- メインの黄色いカード --}}
                 {{-- スロットコンテナ --}}
                 <div class="flex justify-around items-center gap-[24px]">
-                    {{-- スロット1:メイン --}}
-                    <div class="space-y-4 w-[calc((100%-48px)/3)]">
-                        <h2 class="text-[#d97706] font-bold text-xl">メイン</h2>
-                        <div x-data="{ rolling: false }" class="space-y-4">
-                            <div class="slot-container aspect-square bg-white rounded-2xl border-4 border-[#d97706] overflow-hidden shadow-inner">
-                                {{-- ここにJSで生成した<ul><li>が入る --}}
-                                <ul id="slot-main" class="absolute inset-0 m-0 p-0 list-none"></ul>
-                                <div class="absolute inset-0 pointer-events-none z-10"
-                                    style="background: linear-gradient(to bottom,
-                                        rgba(0,0,0,0.8) 0%,
-                                        rgba(0,0,0,0) 17%,
-                                        rgba(0,0,0,0) 83%,
-                                        rgba(0,0,0,0.8) 100%
-                                    );"
-                                >
-                                </div>
-                            </div>
-                            {{-- $isReadyがfalseならスタートボタン無効化 --}}
-                            <button
-                            @if ($isReady)
-                                {{-- @click="rolling = !rolling; toggleSlot(1, rolling)" --}}
-                                @click="rolling = !rolling; toggleSlot(window.MENU_TYPES.MAIN, rolling)"
-                            @endif
-                                {{-- :class="rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]'" --}}
-                                :class="!{{ $isReady ? 'true' : 'false' }} ? 'bg-red-400 cursor-not-allowed opacity-50' : (rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]')"
-                                class="w-full py-3 bg-[#fbbf24] hover:bg-[#f59e0b] text-white font-bold rounded-xl shadow-md transition-all active:scale-95"
-                            >
-                                {{-- <span x-text="rolling ? 'ストップ' : 'スタート'"></span> --}}
-                                <span x-text="!{{ $isReady ? 'true' : 'false' }} ? '準備中' : (rolling ? 'ストップ' : 'スタート')"></span>
-                            </button>
-                        </div>
-                    </div>
-                    {{-- スロット2:副菜A --}}
-                    <div class="space-y-4 w-[calc((100%-48px)/3)]">
-                        <h2 class="text-[#d97706] font-bold text-xl">副菜A</h2>
-                        <div x-data="{ rolling: false }" class="space-y-4">
-                            <div class="slot-container aspect-square bg-white rounded-2xl border-4 border-[#d97706] overflow-hidden shadow-inner">
-                                {{-- ここにJSで生成した<ul><li>が入る --}}
-                                <ul id="slot-sub-a" class="absolute inset-0 m-0 p-0 list-none"></ul>
-                                <div class="absolute inset-0 pointer-events-none z-10"
-                                    style="background: linear-gradient(to bottom,
-                                        rgba(0,0,0,0.8) 0%,
-                                        rgba(0,0,0,0) 17%,
-                                        rgba(0,0,0,0) 83%,
-                                        rgba(0,0,0,0.8) 100%
-                                    );"
-                                >
-                                </div>
-                            </div>
-                            {{-- <button
-                                @click="rolling = !rolling; toggleSlot(2, rolling)"
-                                :class="rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]'"
-                                class="w-full py-3 bg-[#fbbf24] hover:bg-[#f59e0b] text-white font-bold rounded-xl shadow-md transition-all active:scale-95"
-                            >
-                                <span x-text="rolling ? 'ストップ' : 'スタート'"></span>
-                            </button> --}}
-                            {{-- $isReadyがfalseならスタートボタン無効化 --}}
-                            <button
-                            @if ($isReady)
-                                @click="rolling = !rolling; toggleSlot(window.MENU_TYPES.SIDE_A, rolling)"
-                            @endif
-                                {{-- :class="rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]'" --}}
-                                :class="!{{ $isReady ? 'true' : 'false' }} ? 'bg-red-400 cursor-not-allowed opacity-50' : (rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]')"
-                                class="w-full py-3 bg-[#fbbf24] hover:bg-[#f59e0b] text-white font-bold rounded-xl shadow-md transition-all active:scale-95"
-                            >
-                                {{-- <span x-text="rolling ? 'ストップ' : 'スタート'"></span> --}}
-                                <span x-text="!{{ $isReady ? 'true' : 'false' }} ? '準備中' : (rolling ? 'ストップ' : 'スタート')"></span>
-                            </button>
-                        </div>
-                    </div>
-                    {{-- スロット3:副菜B --}}
-                    <div class="space-y-4 w-[calc((100%-48px)/3)]">
-                        <h2 class="text-[#d97706] font-bold text-xl">副菜B</h2>
-                        <div x-data="{ rolling: false }" class="space-y-4">
-                            <div class="slot-container aspect-square bg-white rounded-2xl border-4 border-[#d97706] overflow-hidden shadow-inner">
-                            {{-- ここにJSで生成した<ul><li>が入る --}}
-                                <ul id="slot-sub-b" class="absolute inset-0 m-0 p-0 list-none"></ul>
-                                <div class="absolute inset-0 pointer-events-none z-10"
-                                    style="background: linear-gradient(to bottom,
-                                        rgba(0,0,0,0.8) 0%,
-                                        rgba(0,0,0,0) 17%,
-                                        rgba(0,0,0,0) 83%,
-                                        rgba(0,0,0,0.8) 100%
-                                    );"
-                                >
-                                </div>
-                            </div>
-                            {{-- <button
-                                @click="rolling = !rolling; toggleSlot(3, rolling)"
-                                :class="rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]'"
-                                class="w-full py-3 bg-[#fbbf24] hover:bg-[#f59e0b] text-white font-bold rounded-xl shadow-md transition-all active:scale-95"
-                            >
-                                <span x-text="rolling ? 'ストップ' : 'スタート'"></span>
-                            </button> --}}
-                            {{-- $isReadyがfalseならスタートボタン無効化 --}}
-                            <button
-                            @if ($isReady)
-                                {{-- @click="rolling = !rolling; toggleSlot(3, rolling)" --}}
-                                @click="rolling = !rolling; toggleSlot(window.MENU_TYPES.SIDE_B, rolling)"
-                            @endif
-                                {{-- :class="rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]'" --}}
-                                :class="!{{ $isReady ? 'true' : 'false' }} ? 'bg-red-400 cursor-not-allowed opacity-50' : (rolling ? 'bg-red-500 hover:bg-red-600' : 'bg-[#FBBF24] hover:bg-[#F59E0B]')"
-                                class="w-full py-3 bg-[#fbbf24] hover:bg-[#f59e0b] text-white font-bold rounded-xl shadow-md transition-all active:scale-95"
-                            >
-                                {{-- <span x-text="rolling ? 'ストップ' : 'スタート'"></span> --}}
-                                <span x-text="!{{ $isReady ? 'true' : 'false' }} ? '準備中' : (rolling ? 'ストップ' : 'スタート')"></span>
-                            </button>
-                        </div>
-                    </div>
+                    @foreach ($slots as $slot )
+                        <x-slot-panel
+                            :id="$slot['id']"
+                            :label="$slot['label']"
+                            :type="$slot['type']"
+                            :isReady="$isReady"
+                        />
+                    @endforeach
                 </div>
                 <div id="slot-result-display"
      class="hidden mt-6 p-4 bg-white/50 backdrop-blur-sm rounded-2xl border-2 border-dashed border-orange-300 flex items-center justify-center">


### PR DESCRIPTION
①メンテナンス性の向上
---
もし将来的にスロットの枠線を太くしたり、ボタンのデザインを変えたくなっても、slot-panel.blade.php という 1つのファイルを直すだけで全スロットに反映されるように修正

②バグの抑制
---
修正前：「メイン」は直したけど「副菜B」を直し忘れた、といった修正漏れが起きやすい状態
修正後：共通化したことでその心配がなくなった

③可読性の向上
---
100行以上のコードが激減したことにより
index.blade.php を見た人が、「あ、ここでは3つのパネルをループで回しているんだな」と構造を一瞬で理解できるようになった