### PR TITLE
例外時のログ出力とレスポンスの分離 #27

### DIFF
--- a/app/Http/Controllers/MealRecordController.php
+++ b/app/Http/Controllers/MealRecordController.php
@@ -45,26 +45,30 @@ class MealRecordController extends Controller
     }
 
     // 献立登録処理
-    // public function store(Request $request) {
     public function store(StoreMealRecordRequest $request) {
-        //     // ログにリクエスト内容を出力
-        // Log::info('保存ボタンが押されました', $request->all());
+        // 1. バリデーション済みのデータを取得（tryの外でOK）
+    $validated = $request->validated();
 
-        // return response()->json([
-        //     'received_data' => $request->all()
-        // ], 200);
-
-        // 1. 同日に2件は献立を保存できないようにする
+    try {
+        // --- 修正ポイント1：重複チェックを try の中に入れる ---
         $today = now()->format('Y-m-d');
-        $exists = MealRecord::where('user_id', Auth::id())->where('date', $today)->exists();
+        $exists = MealRecord::where('user_id', Auth::id())
+                            ->where('date', $today)
+                            ->exists();
+
         if($exists) {
+            // あえて例外(Exception)を投げず、警告ログだけ残して409を返しても良いですが、
+            // 「不正な操作」として記録したい場合は、ここでもログを出すか、例外を投げます。
+            Log::warning('献立の重複保存が試行されました', [
+                'user_id' => Auth::id(),
+                'date'    => $today,
+                'input'   => $request->all(),
+            ]);
+
             return response()->json([
                 'message' => '本日の献立はすでに保存済みです。'
             ], 409);
         }
-
-        // 2. バリデーション済みのデータを取得
-        $validated = $request->validated();
 
         // 2. バリデーション → StoreMealRecordRequestでバリデーションを管理するためコメントアウト
         // $userId = Auth::id();    //今ログインしている人のIDを取得
@@ -95,7 +99,7 @@ class MealRecordController extends Controller
         //     'sub_dish_b_id' => 'required|exists:menus,id',
         // ]);
 
-        try {
+        // try {
             return DB::transaction(function() use ($validated) {
                 // 3. 親（MealRecord）の作成
                 $record = MealRecord::create([
@@ -121,9 +125,23 @@ class MealRecordController extends Controller
 
                 return response()->json(['message'=> '献立を保存しました！'], 200);
             });
-        } catch(\Exception $e) {
-            Log::error("献立保存失敗: " . $e->getMessage());
-            return response()->json(['message' => '保存に失敗しました'], 500);
+        // } catch(\Exception $e) {
+        //     Log::error("献立保存失敗: " . $e->getMessage());
+        //     return response()->json(['message' => '保存に失敗しました'], 500);
+        // }
+        } catch(\Throwable $e) {
+            // 1. ログに詳細なコンテキスト（状況）を記録する
+            Log::error('献立保存に失敗', [
+                'user_id' =>    Auth::id(),
+                'input' =>      $request->all(),
+                'error' =>      $e->getMessage(),
+                'trace' =>      $e->getTraceAsString(),
+            ]);
+
+            // 2. ユーザーには内部構造を見せずに、丁寧なエラーメッセージを返す
+            return response()->json([
+                'message' =>    '保存に失敗しました。時間をおいて再度お試しください。'
+            ], 500);
         }
 
         // try {
@@ -183,21 +201,32 @@ class MealRecordController extends Controller
         //     'ids'   => 'required|array|min:1',      //idsは必須、配列形式、1つ以上
         //     'ids.*' => 'integer',                       //配列の中身はすべて数字
         // ]);
+        try {
+            // 削除の実行（自分のデータ、かつ指定されたIDのみ）
+            // $deletedには実際に削除した件数が返ってくる
+            $deleted = MealRecord::where('user_id', Auth::id())
+                                    ->whereIn('id', $validated['ids'])
+                                    ->delete();
 
-        // 削除の実行（自分のデータ、かつ指定されたIDのみ）
-        // $deletedには実際に削除した件数が返ってくる
-        $deleted = MealRecord::where('user_id', Auth::id())
-                                ->whereIn('id', $validated['ids'])
-                                ->delete();
+            session()->flash('message', "{$deleted}件の献立を削除しました。");
+            session()->flash('type', 'success');
 
-        session()->flash('message', "{$deleted}件の献立を削除しました。");
-        session()->flash('type', 'success');
+            // JSONレスポンス（JavaScript側の通知用）
+            return response()->json([
+                    'message' => "{$deleted}件の献立を削除しました。"
+            ], 200);
+        } catch (\Throwable $e) {
 
-        // JSONレスポンス（JavaScript側の通知用）
-        return response()->json([
-                'message' => "{$deleted}件の献立を削除しました。"
-        ], 200);
+            Log::eeror('献立の一括削除に失敗', [
+                'user_id'   =>      Auth::id(),
+                'ids'       =>      $validated['ids'],
+                'error'     =>      $e->getMessage(),
+                'trace'     =>      $e->getTraceAsString(),
+            ]);
 
+            return response()->json([
+                'message' => '削除処理中にエラーが発生しました。時間をおいて再度お試しください。'
+            ], 500);
 
             // $ids = $request->input('ids');
 
@@ -220,6 +249,7 @@ class MealRecordController extends Controller
             // return response()->json([
             //     'message' => '削除成功'
             // ], 200);
+        }
 
     }
 }

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -8,6 +8,7 @@ use App\Models\Menu;
 use App\Models\Type;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rules\Enum;
 
@@ -48,44 +49,64 @@ class MenuController extends Controller
         //     'image_path.mimes' => 'png, jpg, jpeg, gif形式の画像を選択してください。',
         // ]);
 
-        // 2.写真の保存処理
-        $imagePath = null;
-        if($request->hasFile('image_path')) {
-            $imagePath = $request->file('image_path')->store('menu_images', 'public');
-        }
+        try {
 
-        // 3. データベースに保存
-        // Menu::create([
-        //     'user_id'       => Auth::id(),
-        //     'name'          => $validated['menu_name'],
-        //     'type_id'       => $validated['type_id'],
-        //     'image_path'    => $imagePath,
-        //     'recipe_url'    => $validated['recipe_url'] ?? null,
-        //     'memo'          => $validated['memo'] ?? null,
-        // ]);
-        Auth::user()->menus()->create([
-            'name'          => $validated['menu_name'],
-            'type_id'       => $validated['type_id'],
-            'image_path'    => $imagePath,
-            'recipe_url'    => $validated['recipe_url'] ?? null,
-            'memo'          => $validated['memo'] ?? null,
-        ]);
+            // 2.写真の保存処理
+            $imagePath = null;
+            if($request->hasFile('image_path')) {
+                $imagePath = $request->file('image_path')->store('menu_images', 'public');
+                }
 
-        // 3.データベースに保存
-        // Menu::create([
-        //     'user_id' => Auth::id(),
-        //     'name' => $request->menu_name,
-        //     'type_id' => $request->type_id,
-        //     'image_path' => $imagePath,
-        //     'recipe_url' => $request->recipe_url,
-        //     'memo' => $request->memo,
-        // ]);
+                // 3. データベースに保存
+                // Menu::create([
+                    //     'user_id'       => Auth::id(),
+                    //     'name'          => $validated['menu_name'],
+                    //     'type_id'       => $validated['type_id'],
+                    //     'image_path'    => $imagePath,
+                    //     'recipe_url'    => $validated['recipe_url'] ?? null,
+                    //     'memo'          => $validated['memo'] ?? null,
+                    // ]);
 
-        // return redirect()->route('menus.index')->with('success', 'メニューを登録しました。');
-        return redirect()->route('menus.index')->with([
-            'message' => 'メニューを登録しました',
-            'type' => 'success',
+                    Auth::user()->menus()->create([
+                        'name'          => $validated['menu_name'],
+                        'type_id'       => $validated['type_id'],
+                        'image_path'    => $imagePath,
+                        'recipe_url'    => $validated['recipe_url'] ?? null,
+                        'memo'          => $validated['memo'] ?? null,
+                        ]);
+
+                        // 3.データベースに保存
+                        // Menu::create([
+                            //     'user_id' => Auth::id(),
+                            //     'name' => $request->menu_name,
+                            //     'type_id' => $request->type_id,
+                            //     'image_path' => $imagePath,
+                            //     'recipe_url' => $request->recipe_url,
+                            //     'memo' => $request->memo,
+                            // ]);
+
+                            // return redirect()->route('menus.index')->with('success', 'メニューを登録しました。');
+                            return redirect()->route('menus.index')->with([
+                                'message' => 'メニューを登録しました',
+                                'type' => 'success',
+                                ]);
+        } catch (\Throwable $e) {
+            if ($imagePath) {
+                Storage::disk('public')->delete($imagePath);
+            }
+
+            Log::error('メニュー登録失敗', [
+                'user_id'       =>  Auth::id(),
+                'input'         =>  $request->except('image_path'),
+                'error'         =>  $e->getMessage(),
+                'trace'         =>  $e->getTraceAsString(),
             ]);
+
+            return redirect()->back()->withInput()->with([
+                'message'   =>  '登録中にエラーが発生しました。時間をおいて再度お試しください。',
+                'type'      =>  'danger',
+            ]);
+        }
     }
 
     public function index() {
@@ -143,18 +164,34 @@ class MenuController extends Controller
         //     ]);
         // }
 
-        // 2. サーバー上の画像を削除
-        if($menu->image_path) {
-            Storage::disk('public')->delete($menu->image_path);
+        try {
+            // 3. データベースから削除
+            $menu->delete();
+
+
+            // 2. サーバー上の画像を削除
+            if($menu->image_path) {
+                Storage::disk('public')->delete($menu->image_path);
+            }
+
+
+            // 4. 一覧画面に戻す
+            return redirect()->route('menus.index')->with([
+                'message' => 'メニューを削除しました。',
+                'type' => 'success',
+                ]);
+        } catch (\Throwable $e) {
+            Log::error('メニュー削除失敗', [
+                'user_id'   =>  Auth::id(),
+                'menu_id'   =>  $menu->id,
+                'error'     =>  $e->getMessage(),
+                'trace'     =>  $e->getTraceAsString(),
+            ]);
+
+            return redirect()->route('menus.index')->with([
+                'message'   =>  '削除中にエラーが発生しました。時間をおいて再度お試しください。',
+                'type'      => 'danger',
+            ]);
         }
-
-        // 3. データベースから削除
-        $menu->delete();
-
-        // 4. 一覧画面に戻す
-        return redirect()->route('menus.index')->with([
-            'message' => 'メニューを削除しました。',
-            'type' => 'success',
-        ]);
     }
 }


### PR DESCRIPTION
【MealRecordController（献立履歴関連）】
①store（登録処理）
---
・同日の重複チェックを含む一連の保存処理を try ブロック内に移動
・万が一のDBエラーや予期せぬ不具合を \Throwable で網羅的にキャッチ

②selectDestroy（一括削除処理）
---
・処理全体を try-catch で囲み、堅牢化
・エラー発生時に、「どのデータ（ids）を消そうとして失敗したのか」をログに記録するよう改善

【MenuController（メニュー関連）】
①store（登録処理）
---
・画像保存とDB登録を try-catch で一括管理
・ロールバック処理の追加：
　DB登録が失敗した際、ストレージに保存されてしまった画像を自動削除し、サーバーにゴミを残さない仕組みを実装
・ログには画像バイナリを除外した $request->except('image_path') を記録

②destroy（単一削除処理）
---
・認可チェック（権限確認）は仕様通りの挙動（403相当）として try の外に置き、実際のデータ削除処理のみを try-catch で保護