### PR TITLE
Policy の導入 #31

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -8,9 +8,12 @@ use App\Models\Type;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class MenuController extends Controller
 {
+    use AuthorizesRequests;
 
     // メニュー登録画面を表示
     public function create() {
@@ -90,18 +93,11 @@ class MenuController extends Controller
 
     // メニューの削除処理
     public function destroy(Menu $menu) {
-        // 現在ログインしているユーザー
-        $user = Auth::user();
-
-        // 認可チェック：「メニューの所有者ではない」かつ「管理者でもない」場合
-        if($menu->user_id !== $user->id && $user->role !== 'admin') {
-            return redirect()->route('menus.index')->with([
-                'message' => '削除する権限がありません',
-                'type' => 'danger',
-            ]);
-        }
-
         try {
+            // Laravelが自動的に MenuPolicy の delete メソッドを呼び出してチェックする
+            // 権限がない場合は自動的に「catch」に入る
+            $this->authorize('delete', $menu);
+
             // データベースから削除
             $menu->delete();
 
@@ -116,6 +112,15 @@ class MenuController extends Controller
             return redirect()->route('menus.index')->with([
                 'message' => 'メニューを削除しました。',
                 'type' => 'success',
+            ]);
+
+        } catch (AuthorizationException $e) {
+            // 👈 3. 権限エラー（403）が発生した場合はここへジャンプします！
+            Log::warning("不審なアクセス: ユーザーID " . auth()->id() . " がメニューID " . $menu->id . " を削除しようとしました。");
+
+            return redirect()->route('menus.index')->with([
+                'message' => '削除する権限がありません。',
+                'type' => 'danger', // 赤色のFlashメッセージにする場合
             ]);
 
         } catch (\Throwable $e) {

--- a/app/Policies/MenuPolicy.php
+++ b/app/Policies/MenuPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Menu;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class MenuPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Menu $menu): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Menu $menu): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Menu $menu): bool
+    {
+        // 所有者本人。または管理者（admin）であれば、true を返す
+        return $user->id === $menu->user_id || $user->role === 'admin';
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Menu $menu): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Menu $menu): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Policyの導入

①MenuPolicy.php作成
---
delete処理を実装
・「所有者本人」または「管理者(admin)」だけを許可するルールを1箇所に集約
 ・将来の仕様変更（edit, updateなど）にも使い回せる王道の設計へ

②if 文の認可ロジックを排除
---
$this->authorize() の導入により「認可チェック」を Policy へ委託

③try-catch追加
---
・不正アクセス時は 403 画面を出さずに try-catch で優しくインターセプト
・監査ログ(Log::warning)を刻みつつ、Flashメッセージで「権限がありません」と元の画面へ還流