### PR TITLE
SlotController の「3つ以上」定数化 #35

### DIFF
--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Auth;
 
 class SlotController extends Controller
 {
+    // 最低限の各メニューの登録個数を定数化
+    private const MIN_MENUS_PER_TYPE = 3;
+
     // スロット画面を表示
     public function index() {
         // ログインユーザーのメニューを一括取得
@@ -20,7 +23,8 @@ class SlotController extends Controller
         ];
 
         // 全てのタイプが3つ以上登録されているか（スロット可能か）を判定
-        $isReady = ($counts['main'] >= 3 && $counts['side_a'] >= 3 && $counts['side_b'] >= 3);
+        // $isReady = ($counts['main'] >= 3 && $counts['side_a'] >= 3 && $counts['side_b'] >= 3);
+        $isReady = collect($counts)->every(fn($c) => $c >= self::MIN_MENUS_PER_TYPE);
 
         return view('slot.index', compact('menus', 'counts', 'isReady'));
     }

--- a/tests/Feature/SlotControllerTest.php
+++ b/tests/Feature/SlotControllerTest.php
@@ -129,4 +129,25 @@ class SlotControllerTest extends TestCase
         $response->assertSee('副菜A：0/3');
         $response->assertSee('副菜B：0/3');
     }
+
+    /**
+     * 【正常系】メニューの登録件数が各料理タイプ3件以上ある場合、スロット画面が正常に表示される
+     */
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function test_slot_opens_normally_when_menu_count_is_sufficient(): void
+    {
+        $user = User::factory()->create();
+
+        // 💡 既存のテストと違い、きっちり「3件ずつ」作成して条件を満たす
+        Menu::factory()->count(3)->create(['user_id' => $user->id, 'type_id' => MenuType::Main->value]);
+        Menu::factory()->count(3)->create(['user_id' => $user->id, 'type_id' => MenuType::SideA->value]);
+        Menu::factory()->count(3)->create(['user_id' => $user->id, 'type_id' => MenuType::SideB->value]);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertOk();
+
+        // 💡 3件以上あるので、警告メッセージが「表示されていないこと」を検証
+        $response->assertDontSee('スロットを回すための登録メニュー件数が足りません。');
+    }
 }


### PR DESCRIPTION
①マジックナンバーのクラス定数化（self::）
---
`private const MIN_MENUS_PER_TYPE = 3;` 
メリット：将来「やっぱり5件必要」と仕様変更されても、この定数を1箇所変えるだけでアプリ全体が追従。

②コレクション関数（every）の導入
---
やったこと：&& で繋げていた条件式を、
`collect($counts)->every(fn($c) => $c >= self::MIN_MENUS_PER_TYPE) `の1行に集約。
メリット：将来「汁物」や「デザート」などの料理タイプが増えても、この判定コードは1文字も書き換える必要がない
「型に強いコード」になった。

③テスト追加
---
今回のリファクタリングの正しさを検証するため、SlotControllerTestに
【正常系】メニューの登録件数が各料理タイプ3件以上ある場合、スロット画面が正常に表示される
を追加。
dd() を用いて、裏側のSQLiteデータベースに狙い通りのデータ（計9件）が生成されていることも目視で確認。